### PR TITLE
fix(ci): comment out go mod tidy in .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ version: 2
 before:
   hooks:
     # You may remove this if you don't use go modules.
-    - go mod tidy
+    # - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
 


### PR DESCRIPTION
Comment out the 'go mod tidy' hook in goreleaser configuration.